### PR TITLE
Add CTTS monorepo skeleton

### DIFF
--- a/ctts-monorepo/.eslintrc.json
+++ b/ctts-monorepo/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+  "env": {
+    "node": true,
+    "browser": true,
+    "es2020": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {}
+}

--- a/ctts-monorepo/.github/workflows/svc-build.yml
+++ b/ctts-monorepo/.github/workflows/svc-build.yml
@@ -1,0 +1,14 @@
+name: Service Build
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci -w services/trainer -w services/admin
+      - run: npx eslint services --ext .ts
+      - run: npm test -w services/trainer -w services/admin -- --runInBand
+      - run: npx tsc -b services/trainer/tsconfig.json services/admin/tsconfig.json

--- a/ctts-monorepo/.github/workflows/ui-build.yml
+++ b/ctts-monorepo/.github/workflows/ui-build.yml
@@ -1,0 +1,20 @@
+name: UI Build
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npx eslint src --ext .ts,.tsx
+      - run: npm test -- --runInBand
+      - run: npx vite build
+      - uses: aws-actions/s3-sync@v1
+        with:
+          args: --region us-east-1 ./dist s3://ctts-spa-devint

--- a/ctts-monorepo/.gitignore
+++ b/ctts-monorepo/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+coverage/

--- a/ctts-monorepo/.prettierrc
+++ b/ctts-monorepo/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/ctts-monorepo/README.md
+++ b/ctts-monorepo/README.md
@@ -1,0 +1,25 @@
+# Certification & Training Tracking System (CTTS)
+
+## Prerequisites
+- Node 18
+- AWS CLI v2
+- AWS CDK v2
+- AWS SAM CLI
+
+## Quick Start
+```bash
+npm install -w ui
+npm install -w services/trainer
+npm install -w services/admin
+```
+
+## Seed Data
+Run:
+```bash
+TABLE=<dynamoName> npx ts-node scripts/seed-dev-data.ts
+```
+
+## Local API
+```bash
+sam local start-api -t infra/trainer-svc/template.yaml
+```

--- a/ctts-monorepo/azure-pipelines/build.yml
+++ b/ctts-monorepo/azure-pipelines/build.yml
@@ -1,0 +1,14 @@
+trigger:
+- dev
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- task: NodeTool@0
+  inputs:
+    versionSpec: '18.x'
+- script: npm ci -w services/trainer -w services/admin
+- script: npx tsc -b services/trainer/tsconfig.json services/admin/tsconfig.json
+- publish: $(System.DefaultWorkingDirectory)
+  artifact: lambdas

--- a/ctts-monorepo/azure-pipelines/deploy.yml
+++ b/ctts-monorepo/azure-pipelines/deploy.yml
@@ -1,0 +1,15 @@
+dependencies:
+- build
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+parameters:
+- name: stackName
+  type: string
+
+steps:
+- task: NodeTool@0
+  inputs:
+    versionSpec: '18.x'
+- script: sam deploy -t infra/trainer-svc/template.yaml --stack-name ${{ parameters.stackName }} --no-confirm-changeset --region us-east-1

--- a/ctts-monorepo/infra/admin-svc/template.yaml
+++ b/ctts-monorepo/infra/admin-svc/template.yaml
@@ -1,0 +1,37 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Admin Service
+Tags:
+  Application: CTTS
+  Env: DevInt
+  Owner: BEA
+  DataGovernor: CDO
+  Compliance: Sec530
+  PII: No
+Resources:
+  AdminApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: dev
+      Name: admin-api-dev
+      Cors: "*"
+  SummaryFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handler.handler
+      CodeUri: ../../services/admin
+      Events:
+        Summary:
+          Type: Api
+          Properties:
+            RestApiId: !Ref AdminApi
+            Path: /dashboard/summary
+            Method: get
+  SubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties:
+      DBSubnetGroupDescription: placeholder
+      SubnetIds: []
+Outputs:
+  ApiUrl:
+    Value: !Sub https://${AdminApi}.execute-api.${AWS::Region}.amazonaws.com/dev

--- a/ctts-monorepo/infra/cdk/bin/cdk.ts
+++ b/ctts-monorepo/infra/cdk/bin/cdk.ts
@@ -1,0 +1,8 @@
+import { App } from 'aws-cdk-lib';
+import { CoreNetworkStack } from '../lib/core-network';
+
+const app = new App();
+
+new CoreNetworkStack(app, 'CoreNetworkStack', {
+  env: { region: 'us-east-1' },
+});

--- a/ctts-monorepo/infra/cdk/lib/core-network.ts
+++ b/ctts-monorepo/infra/cdk/lib/core-network.ts
@@ -1,0 +1,43 @@
+import { Stack, StackProps, Tags } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Bucket, BlockPublicAccess } from 'aws-cdk-lib/aws-s3';
+import { Distribution, OriginAccessIdentity, ViewerProtocolPolicy } from 'aws-cdk-lib/aws-cloudfront';
+import { S3Origin } from 'aws-cdk-lib/aws-cloudfront-origins';
+import { Vpc, SubnetType } from 'aws-cdk-lib/aws-ec2';
+
+export class CoreNetworkStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    Tags.of(this).add('Application', 'CTTS');
+    Tags.of(this).add('Env', 'DevInt');
+    Tags.of(this).add('Owner', 'BEA');
+    Tags.of(this).add('DataGovernor', 'CDO');
+    Tags.of(this).add('Compliance', 'Sec530');
+    Tags.of(this).add('PII', 'No');
+
+    const vpc = Vpc.fromLookup(this, 'ImportedVpc', { vpcId: 'vpc-xxxxxxxx' });
+
+    const privateSubnet = { subnetType: SubnetType.PRIVATE_WITH_EGRESS };
+    const publicSubnet = { subnetType: SubnetType.PUBLIC };
+
+    const spaBucket = new Bucket(this, 'SpaBucket', {
+      bucketName: 'ctts-spa-devint',
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      versioned: true,
+    });
+
+    const oai = new OriginAccessIdentity(this, 'OAI');
+
+    const distribution = new Distribution(this, 'SpaDistribution', {
+      defaultBehavior: {
+        origin: new S3Origin(spaBucket, { originAccessIdentity: oai }),
+        viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+      },
+      domainNames: ['apps-d.dbhds.virginia.gov'],
+    });
+
+    this.exportValue(spaBucket.bucketName, { name: 'SpaBucketName' });
+    this.exportValue(distribution.domainName, { name: 'SpaCfDomain' });
+  }
+}

--- a/ctts-monorepo/infra/trainer-svc/template.yaml
+++ b/ctts-monorepo/infra/trainer-svc/template.yaml
@@ -1,0 +1,76 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Trainer Service
+Tags:
+  Application: CTTS
+  Env: DevInt
+  Owner: BEA
+  DataGovernor: CDO
+  Compliance: Sec530
+  PII: No
+Globals:
+  Function:
+    Runtime: nodejs18.x
+    MemorySize: 256
+    Timeout: 10
+    Environment:
+      Variables:
+        TABLE: !Ref TrainerTable
+Resources:
+  TrainerTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: TrainerTable
+      AttributeDefinitions:
+        - AttributeName: pk
+          AttributeType: S
+      KeySchema:
+        - AttributeName: pk
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+          Value: CDO
+        - Key: Compliance
+          Value: Sec530
+        - Key: PII
+          Value: No
+  TrainerApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: dev
+      Name: trainer-api-dev
+      Cors: "*"
+  GetTrainersFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handler.get
+      CodeUri: ../../services/trainer
+      Events:
+        GetTrainers:
+          Type: Api
+          Properties:
+            RestApiId: !Ref TrainerApi
+            Path: /trainers
+            Method: get
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref TrainerTable
+  ApproveTrainerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/approve.handler
+      CodeUri: ../../services/trainer
+      Events:
+        ApproveTrainer:
+          Type: Api
+          Properties:
+            RestApiId: !Ref TrainerApi
+            Path: /trainers/{id}/approve
+            Method: put
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref TrainerTable
+Outputs:
+  ApiUrl:
+    Value: !Sub https://${TrainerApi}.execute-api.${AWS::Region}.amazonaws.com/dev
+  TableName:
+    Value: !Ref TrainerTable

--- a/ctts-monorepo/jest.config.js
+++ b/ctts-monorepo/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+};

--- a/ctts-monorepo/package.json
+++ b/ctts-monorepo/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ctts-monorepo",
+  "private": true,
+  "workspaces": ["ui", "services/trainer", "services/admin"],
+  "devDependencies": {
+    "typescript": "^4.9.5",
+    "eslint": "^8.0.0",
+    "@typescript-eslint/parser": "^5.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.0.0",
+    "prettier": "^2.8.0",
+    "jest": "^29.0.0",
+    "@types/jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0"
+  }
+}

--- a/ctts-monorepo/scripts/seed-dev-data.ts
+++ b/ctts-monorepo/scripts/seed-dev-data.ts
@@ -1,0 +1,30 @@
+import { DynamoDBClient, ScanCommand, PutItemCommand } from '@aws-sdk/client-dynamodb';
+
+const TABLE = process.env.TABLE;
+if (!TABLE) {
+  console.error('TABLE env var required');
+  process.exit(1);
+}
+
+const client = new DynamoDBClient({ region: 'us-east-1' });
+
+(async () => {
+  const data = await client.send(new ScanCommand({ TableName: TABLE }));
+  if (!data.Items || data.Items.length === 0) {
+    await client.send(
+      new PutItemCommand({
+        TableName: TABLE,
+        Item: { pk: { S: 'T-001' }, name: { S: 'Alice' } },
+      }),
+    );
+    await client.send(
+      new PutItemCommand({
+        TableName: TABLE,
+        Item: { pk: { S: 'T-002' }, name: { S: 'Bob' } },
+      }),
+    );
+    console.log('Seeded');
+  } else {
+    console.log('Table already has data');
+  }
+})();

--- a/ctts-monorepo/services/admin/package.json
+++ b/ctts-monorepo/services/admin/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "admin-service",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "jest"
+  },
+  "dependencies": {}
+}

--- a/ctts-monorepo/services/admin/src/handler.ts
+++ b/ctts-monorepo/services/admin/src/handler.ts
@@ -1,0 +1,10 @@
+export const handler = async () => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      totalTrainers: 0,
+      pending: 0,
+      kitsOrdered: 0,
+    }),
+  };
+};

--- a/ctts-monorepo/services/admin/tests/handler.test.ts
+++ b/ctts-monorepo/services/admin/tests/handler.test.ts
@@ -1,0 +1,7 @@
+import { handler } from '../src/handler';
+
+test('returns summary', async () => {
+  const res = await handler();
+  const body = JSON.parse(res.body);
+  expect(body).toHaveProperty('totalTrainers');
+});

--- a/ctts-monorepo/services/admin/tsconfig.json
+++ b/ctts-monorepo/services/admin/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/ctts-monorepo/services/trainer/package.json
+++ b/ctts-monorepo/services/trainer/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "trainer-service",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/util-dynamodb": "^3.0.0",
+    "@aws-lambda-powertools/logger": "^1.0.0"
+  }
+}

--- a/ctts-monorepo/services/trainer/src/approve.ts
+++ b/ctts-monorepo/services/trainer/src/approve.ts
@@ -1,0 +1,29 @@
+import { APIGatewayProxyEvent } from 'aws-lambda';
+import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import { Logger } from '@aws-lambda-powertools/logger';
+
+const client = new DynamoDBClient({});
+const logger = new Logger({ serviceName: 'approve-trainer' });
+const TABLE = process.env.TABLE as string;
+
+export const handler = async (event: APIGatewayProxyEvent) => {
+  const id = event.pathParameters?.id || '';
+  if (!/^T-\d{3}$/.test(id)) {
+    return { statusCode: 400, body: 'Invalid id' };
+  }
+  const now = new Date().toISOString();
+  await client.send(
+    new PutItemCommand({
+      TableName: TABLE,
+      Item: {
+        pk: { S: id },
+        approved: { BOOL: true },
+        approvedAt: { S: now },
+      },
+    }),
+  );
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ id, approved: true }),
+  };
+};

--- a/ctts-monorepo/services/trainer/src/handler.ts
+++ b/ctts-monorepo/services/trainer/src/handler.ts
@@ -1,0 +1,33 @@
+import { DynamoDBClient, ScanCommand } from '@aws-sdk/client-dynamodb';
+import { unmarshall } from '@aws-sdk/util-dynamodb';
+import { Logger } from '@aws-lambda-powertools/logger';
+import { Trainer } from './model';
+
+const client = new DynamoDBClient({});
+const logger = new Logger({ serviceName: 'trainer-handler' });
+const TABLE = process.env.TABLE as string;
+
+export const get = async () => {
+  logger.info('Fetching trainers');
+  const data = await client.send(new ScanCommand({ TableName: TABLE }));
+  const items = data.Items ? data.Items.map((i) => unmarshall(i)) : [];
+
+  let trainers: Trainer[];
+  if (items.length === 0) {
+    trainers = [
+      { id: 'T-001', name: 'Alice', status: 'Pending' },
+      { id: 'T-002', name: 'Bob', status: 'Pending' },
+    ];
+  } else {
+    trainers = items.map((i: any) => ({
+      id: i.pk,
+      name: i.name,
+      status: i.approved ? 'Approved' : 'Pending',
+    }));
+  }
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(trainers),
+  };
+};

--- a/ctts-monorepo/services/trainer/src/model.ts
+++ b/ctts-monorepo/services/trainer/src/model.ts
@@ -1,0 +1,3 @@
+import { Trainer as SharedTrainer } from '../../shared/types';
+
+export interface Trainer extends SharedTrainer {}

--- a/ctts-monorepo/services/trainer/tests/handler.test.ts
+++ b/ctts-monorepo/services/trainer/tests/handler.test.ts
@@ -1,0 +1,20 @@
+import { get } from '../src/handler';
+
+jest.mock('@aws-sdk/client-dynamodb', () => {
+  return {
+    DynamoDBClient: jest.fn().mockImplementation(() => ({
+      send: mockSend,
+    })),
+    ScanCommand: class {},
+  };
+});
+
+const mockSend = jest.fn();
+
+describe('get trainers', () => {
+  it('returns fallback trainers when table empty', async () => {
+    mockSend.mockResolvedValue({ Items: [] });
+    const res = await get();
+    expect(JSON.parse(res.body)).toHaveLength(2);
+  });
+});

--- a/ctts-monorepo/services/trainer/tsconfig.json
+++ b/ctts-monorepo/services/trainer/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/ctts-monorepo/shared/types.ts
+++ b/ctts-monorepo/shared/types.ts
@@ -1,0 +1,5 @@
+export interface Trainer {
+  id: string;
+  name: string;
+  status: 'Pending' | 'Approved';
+}

--- a/ctts-monorepo/ui/package.json
+++ b/ctts-monorepo/ui/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ctts-ui",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "vite build",
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-router-dom": "^6.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0"
+  }
+}

--- a/ctts-monorepo/ui/public/index.html
+++ b/ctts-monorepo/ui/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CTTS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/ctts-monorepo/ui/src/App.tsx
+++ b/ctts-monorepo/ui/src/App.tsx
@@ -1,0 +1,21 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { AuthProvider } from './auth/AuthContext';
+import { NavBar } from './components/NavBar';
+import PublicHome from './pages/PublicHome';
+import { TrainerHome } from './pages/TrainerHome';
+import { AdminHome } from './pages/AdminHome';
+
+const App = () => (
+  <AuthProvider>
+    <BrowserRouter>
+      <NavBar />
+      <Routes>
+        <Route path="/" element={<PublicHome />} />
+        <Route path="/trainer" element={<TrainerHome />} />
+        <Route path="/admin" element={<AdminHome />} />
+      </Routes>
+    </BrowserRouter>
+  </AuthProvider>
+);
+
+export default App;

--- a/ctts-monorepo/ui/src/auth/AuthContext.tsx
+++ b/ctts-monorepo/ui/src/auth/AuthContext.tsx
@@ -1,0 +1,19 @@
+import React, { createContext, useState } from 'react';
+
+export type Role = 'Public' | 'Trainer' | 'Admin';
+
+interface AuthContextValue {
+  role: Role;
+  login: (role: Role) => void;
+}
+
+export const AuthContext = createContext<AuthContextValue>({
+  role: 'Public',
+  login: () => {},
+});
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [role, setRole] = useState<Role>('Public');
+  const login = (r: Role) => setRole(r);
+  return <AuthContext.Provider value={{ role, login }}>{children}</AuthContext.Provider>;
+};

--- a/ctts-monorepo/ui/src/components/NavBar.tsx
+++ b/ctts-monorepo/ui/src/components/NavBar.tsx
@@ -1,0 +1,18 @@
+import { useContext } from 'react';
+import { Link } from 'react-router-dom';
+import { AuthContext } from '../auth/AuthContext';
+
+export const NavBar = () => {
+  const { login } = useContext(AuthContext);
+  return (
+    <nav style={{ padding: '1rem', background: '#eee' }}>
+      <Link to="/">Home</Link> | <Link to="/trainer">Trainer</Link> |{' '}
+      <Link to="/admin">Admin</Link>
+      <span style={{ marginLeft: '1rem' }}>
+        <button onClick={() => login('Trainer')}>Trainer</button>
+        <button onClick={() => login('Admin')}>Admin</button>
+        <button onClick={() => login('Public')}>Logout</button>
+      </span>
+    </nav>
+  );
+};

--- a/ctts-monorepo/ui/src/index.tsx
+++ b/ctts-monorepo/ui/src/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/ctts-monorepo/ui/src/pages/AdminHome.tsx
+++ b/ctts-monorepo/ui/src/pages/AdminHome.tsx
@@ -1,0 +1,11 @@
+import { useEffect, useState } from 'react';
+
+export const AdminHome = () => {
+  const [summary, setSummary] = useState<any>(null);
+  useEffect(() => {
+    fetch('/dashboard/summary')
+      .then((res) => res.json())
+      .then(setSummary);
+  }, []);
+  return <pre>{summary ? JSON.stringify(summary, null, 2) : 'Loading...'}</pre>;
+};

--- a/ctts-monorepo/ui/src/pages/PublicHome.tsx
+++ b/ctts-monorepo/ui/src/pages/PublicHome.tsx
@@ -1,0 +1,9 @@
+const PublicHome = () => (
+  <div>
+    <h1>Welcome to CTTS</h1>
+    <p>
+      Learn about REVIVE <a href="https://dbhds.virginia.gov">here</a>.
+    </p>
+  </div>
+);
+export default PublicHome;

--- a/ctts-monorepo/ui/src/pages/TrainerHome.tsx
+++ b/ctts-monorepo/ui/src/pages/TrainerHome.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import { Trainer } from '../../shared/types';
+
+export const TrainerHome = () => {
+  const [trainers, setTrainers] = useState<Trainer[]>([]);
+
+  useEffect(() => {
+    fetch('/trainers')
+      .then((res) => res.json())
+      .then(setTrainers);
+  }, []);
+
+  const approve = (id: string) => {
+    setTrainers((prev) =>
+      prev.map((t) => (t.id === id ? { ...t, status: 'Approved' } : t)),
+    );
+    fetch(`/trainers/${id}/approve`, { method: 'PUT' });
+  };
+
+  return (
+    <table>
+      <tbody>
+        {trainers.map((t) => (
+          <tr key={t.id}>
+            <td>{t.id}</td>
+            <td>{t.name}</td>
+            <td>{t.status}</td>
+            <td>
+              {t.status === 'Pending' && (
+                <button onClick={() => approve(t.id)}>Approve</button>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};

--- a/ctts-monorepo/ui/tests/App.test.tsx
+++ b/ctts-monorepo/ui/tests/App.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import App from '../src/App';
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue({
+    json: () => Promise.resolve([{ id: 'T-001', name: 'Alice', status: 'Pending' }]),
+  }) as any;
+});
+
+test('renders trainer row after login', async () => {
+  render(<App />);
+  screen.getByText('Trainer').click();
+  expect(await screen.findByText('Alice')).toBeInTheDocument();
+});

--- a/ctts-monorepo/ui/tsconfig.json
+++ b/ctts-monorepo/ui/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/ctts-monorepo/ui/vite.config.ts
+++ b/ctts-monorepo/ui/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- initialize CTTS monorepo with infrastructure, services, UI, and CI scaffolding

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npx cdk synth infra/cdk` *(fails: 403 Forbidden)*
- `sam validate -t infra/trainer-svc/template.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cb774bdc88328b6144fcc465e3d7a